### PR TITLE
Fix issue with not allow non-autorenewing subs

### DIFF
--- a/internal/itunes/receipt.go
+++ b/internal/itunes/receipt.go
@@ -533,7 +533,7 @@ func (iapr *IAPResponse) currentlyActiveTimedSubscription() string {
 	timedStatus := ""
 
 	for _, info := range iapr.PendingRenewalInfo {
-		if info.SubscriptionExpirationIntent != "" || info.SubscriptionAutoRenewStatus == "0" {
+		if info.SubscriptionExpirationIntent != "" {
 			timedStatus = ""
 		} else if info.SubscriptionAutoRenewProductID == "com.christianselig.apollo.sub.monthly" {
 			timedStatus = SubscriptionMonthly


### PR DESCRIPTION
I'm a silly goose and when I sent André code I added in some code that made it so if you bought a subscription then turned off autorenew it would not think you had an active subscription. (For instance if you bought a year subscription, turned autorenew off because you're afraid of things autorenewing, you should still get service for another year)